### PR TITLE
Add React portfolio site skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-"# simple-project-react" 
+# Personal Portfolio
+
+This project contains a simple React portfolio website built with Vite, TailwindCSS, and Framer Motion. It demonstrates animations and a minimal layout for a senior full-stack developer.
+
+## Available Scripts
+
+- `npm run dev` – start the development server
+- `npm run build` – build for production
+- `npm run preview` – preview the production build
+
+## Structure
+
+- `src/components` – reusable UI components
+- `src/pages` – top level pages
+- `src/data` – placeholder data for skills and projects
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfolio</title>
+  </head>
+  <body class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.12.16"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "@vitejs/plugin-react": "^4.0.3",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,12 @@
+import Home from './pages/Home';
+import ThemeSwitcher from './components/ThemeSwitcher';
+
+/** Root component with theme switcher */
+export default function App() {
+  return (
+    <div className="font-sans">
+      <Home />
+      <ThemeSwitcher />
+    </div>
+  );
+}

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,18 @@
+/** About section with short biography */
+export default function About() {
+  return (
+    <section id="about" className="py-20 max-w-3xl mx-auto">
+      <h2 className="text-3xl font-semibold mb-4 text-center">About Me</h2>
+      <p className="text-lg leading-relaxed">
+        I am a senior full-stack developer with seven years of experience building
+        scalable applications using Angular, React, C#, Java, Kotlin, PHP, and
+        Oracle SQL. My passion for clean code and intuitive user experiences has
+        led me to craft solutions for companies across various industries.
+        Fluent in English, I enjoy collaborating with international teams and
+        embracing new challenges. My background in mobile development with
+        Ionic and Flutter enables me to create cross-platform solutions that
+        delight users on any device. I'm always eager to learn and innovate.
+      </p>
+    </section>
+  );
+}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+/** Contact section with simple form */
+export default function Contact() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Placeholder submit action
+    alert('Message sent!');
+  };
+
+  return (
+    <section id="contact" className="py-20 max-w-md mx-auto">
+      <h2 className="text-3xl font-semibold mb-4 text-center">Contact</h2>
+      <p className="text-center mb-4">Email: example@example.com</p>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          className="w-full p-2 border rounded dark:border-gray-700"
+          type="text"
+          name="name"
+          placeholder="Name"
+          value={form.name}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full p-2 border rounded dark:border-gray-700"
+          type="email"
+          name="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={handleChange}
+        />
+        <textarea
+          className="w-full p-2 border rounded dark:border-gray-700"
+          name="message"
+          placeholder="Message"
+          rows={4}
+          value={form.message}
+          onChange={handleChange}
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Send
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,18 @@
+import { motion } from 'framer-motion';
+
+/** Hero section with animated greeting */
+export default function Hero() {
+  return (
+    <section id="hero" className="min-h-screen flex items-center justify-center">
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="text-center"
+      >
+        <h1 className="text-4xl font-bold mb-4">Hello, I'm John Doe</h1>
+        <p className="text-xl">Senior Full-Stack Developer</p>
+      </motion.div>
+    </section>
+  );
+}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,0 +1,34 @@
+import { projects } from '../data/projects';
+import { motion } from 'framer-motion';
+
+/** Projects section with featured projects */
+export default function Projects() {
+  return (
+    <section id="projects" className="py-20 max-w-4xl mx-auto">
+      <h2 className="text-3xl font-semibold mb-8 text-center">Projects</h2>
+      <div className="grid md:grid-cols-2 gap-8">
+        {projects.map((project) => (
+          <motion.div
+            key={project.title}
+            whileHover={{ scale: 1.02 }}
+            className="border p-4 rounded shadow-sm dark:border-gray-700"
+          >
+            <h3 className="text-xl font-medium mb-2">{project.title}</h3>
+            <p className="mb-2">{project.description}</p>
+            <p className="mb-2 text-sm text-gray-500">
+              Tech: {project.tech.join(', ')}
+            </p>
+            <div className="flex gap-4">
+              <a href={project.live} className="text-blue-600 hover:underline">
+                Live
+              </a>
+              <a href={project.repo} className="text-blue-600 hover:underline">
+                GitHub
+              </a>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,0 +1,27 @@
+import { skills } from '../data/skills';
+
+/** Skills section with categorized tags */
+export default function Skills() {
+  return (
+    <section id="skills" className="py-20 max-w-3xl mx-auto">
+      <h2 className="text-3xl font-semibold mb-4 text-center">Skills</h2>
+      <div className="grid grid-cols-2 gap-4">
+        {Object.entries(skills).map(([category, items]) => (
+          <div key={category}>
+            <h3 className="font-medium capitalize mb-2">{category}</h3>
+            <ul className="flex flex-wrap gap-2">
+              {items.map((item) => (
+                <li
+                  key={item}
+                  className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+/** Floating theme switcher to toggle light and dark modes */
+export default function ThemeSwitcher() {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  return (
+    <button
+      className="fixed bottom-4 right-4 p-2 bg-gray-200 dark:bg-gray-700 rounded-full"
+      onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' ? '🌙' : '☀️'}
+    </button>
+  );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,31 @@
+export interface Project {
+  title: string;
+  description: string;
+  tech: string[];
+  live: string;
+  repo: string;
+}
+
+export const projects: Project[] = [
+  {
+    title: 'Project One',
+    description: 'A sample project showcasing frontend skills.',
+    tech: ['React', 'TypeScript'],
+    live: '#',
+    repo: '#',
+  },
+  {
+    title: 'Project Two',
+    description: 'Backend service built with modern technologies.',
+    tech: ['C#', 'Oracle SQL'],
+    live: '#',
+    repo: '#',
+  },
+  {
+    title: 'Project Three',
+    description: 'Mobile application demonstrating cross-platform development.',
+    tech: ['Flutter'],
+    live: '#',
+    repo: '#',
+  },
+];

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,6 @@
+export const skills = {
+  frontend: ['Angular', 'React'],
+  backend: ['C#', 'Java', 'PHP'],
+  mobile: ['Kotlin', 'Flutter', 'Ionic'],
+  database: ['Oracle SQL'],
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,18 @@
+import Hero from '../components/Hero';
+import About from '../components/About';
+import Skills from '../components/Skills';
+import Projects from '../components/Projects';
+import Contact from '../components/Contact';
+
+/** Home page assembling all sections */
+export default function Home() {
+  return (
+    <main>
+      <Hero />
+      <About />
+      <Skills />
+      <Projects />
+      <Contact />
+    </main>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize a simple React portfolio using Vite
- add TailwindCSS and Framer Motion configs
- create components for Hero, About, Skills, Projects, and Contact
- implement floating theme switcher and data placeholders
- document project usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68570433ebac83278cdb9fd3f0e674cc